### PR TITLE
Merge sfrinaldi/30-fix-defaults into develop

### DIFF
--- a/src/utils_config/version_check.py
+++ b/src/utils_config/version_check.py
@@ -4,7 +4,14 @@ import subprocess
 import types
 from datetime import datetime
 
-DEFAULT_MODULES = ["config_stp", "config_um", "config_stp_wcc", "config_stp_esc", "stp_etc_imaging", "stp_etc_esc"]
+DEFAULT_MODULES = [
+    "config_stp",
+    "config_um",
+    "config_stp_wcc",
+    "config_stp_esc",
+    "stp_etc_imaging",
+    "stp_etc_esc",
+]
 
 
 def imports(g_imports):

--- a/src/utils_config/version_check.py
+++ b/src/utils_config/version_check.py
@@ -4,7 +4,7 @@ import subprocess
 import types
 from datetime import datetime
 
-DEFAULT_MODULES = ["config_stp", "config_um", "config_stp_wcc", "config_stp_esc", "etc_wcc", "etc_esc"]
+DEFAULT_MODULES = ["config_stp", "config_um", "config_stp_wcc", "config_stp_esc", "stp_etc_imaging", "stp_etc_esc"]
 
 
 def imports(g_imports):


### PR DESCRIPTION
<!-- 
Please provide a general summary of your changes in the Title. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
- Updating `version_check.py` defaults
  - `etc_wcc` -> `stp_etc_imaging`
  - `etc_esc` -> `stp_etc_esc` 

### Related Issues/PRs
- #30 
- [wcc_designdocs/pull/246](https://github.com/uasal/wcc_designdocs/pull/246#issuecomment-3212227256)

Closes #30 


## Solution Description
Currently, the defaults are out of date so the output table for checking versions for the related etc packages are wrong. Just updated the package names / doesn't look like there is anything else to change.


